### PR TITLE
Highlight cljd files as Clojure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cljd linguist-language=Clojure


### PR DESCRIPTION
Adding the .gitattributes file with the appropriate settings will allow Github to highlight cljd files in the repo as Clojure.  cf https://github.com/Tensegritics/ClojureDart/blob/main/.gitattributes