### PR TITLE
Add re-frame's arrow syntax sugar

### DIFF
--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -12,6 +12,17 @@
 
 (defonce ^:private subscriptions (atom {}))
 
+(defn computation-fn
+  [args]
+  (let [[op f] (take-last 2 args)]
+    (if (nil? f)
+      ;; (reg-sub ::foo (fn [_ _]))
+      op
+      ;; (reg-sub ::foo :-> :foo)
+      (case op
+        :-> (fn [db _] (f db))
+        :=> (fn [db [_ & opts]] (apply f db opts))))))
+
 (defn reg-sub
   "A call to `reg-sub` associates a `query-id` WITH one function.
 
@@ -30,8 +41,8 @@
 
   See also: `subscribe`
   "
-  [subscription-id f]
-  (swap! subscriptions assoc subscription-id f))
+  [subscription-id & args]
+  (swap! subscriptions assoc subscription-id (computation-fn args)))
 
 (defn subscribe
   "Subscribe to derived state, internally using ClojureDart Cells (see the [Cheatsheet](https://github.com/Tensegritics/ClojureDart/blob/main/doc/ClojureDart%20Cheatsheet.pdf))

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -24,7 +24,7 @@
         :=> (fn [db [_ & opts]] (apply f db opts))))))
 
 (defn reg-sub
-  "A call to `reg-sub` associates a `query-id` WITH one function.
+  "A call to `reg-sub` associates a `query-id` with one function.
 
   The two arguments are:
 
@@ -38,6 +38,22 @@
             :query-id
             (fn [db [_ foo]]
               (get db foo)))
+
+  It also supports the arrow syntax sugar of re-frame:
+
+          #!clj
+          ;; equivalent to (reg-sub :query-id (fn [db _] (:foo db)))
+          ;; (subscribe :query-id)
+          (reg-sub
+            :query-id
+            :-> :foo))
+
+          #!clj
+          ;; equivalent to (reg-sub :query-id (fn [db [_ & opts]] (apply get-in db opts)))
+          ;; (subscribe :query-id [:foo :bar])
+          (reg-sub
+            :query-id
+            :=> get-in)
 
   See also: `subscribe`
   "

--- a/test/hti/re_dash_test.cljd
+++ b/test/hti/re_dash_test.cljd
@@ -2,6 +2,12 @@
   (:require [clojure.test :refer :all]
             [hti.re-dash :refer :all]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+(deftest computation-fn-test
+  (let [db {:foo 42
+            :bar {:baz 9001}}])
+  (testing ":->"
+    (let [f (computation-fn (list :-> :foo))]
+      (is (= 42 (f db [])))))
+  (testing ":=>"
+    (let [f (computation-fn (list :=> get-in))]
+      (is (= 9001 (f db [:bar :baz]))))))


### PR DESCRIPTION
Closes #3 

Implementation [copied off re-frame](https://github.com/day8/re-frame/blob/dd18854498b6a5e51ed09bfcbd193d9dd84d8381/src/re_frame/subs.cljc#L162-L182), except I decided to extract it as a function to make testing it easier.

Also, there are no input signals in re-dash yet so it doesn't have to deal with that either. Once there are input signals, it could be done extracted similarly based on `(butlast args)`