### PR TITLE
Signals and shorthands

### DIFF
--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -66,7 +66,7 @@
       (throw (Exception. (str "Subscription not found: " subscription-id))))))
 
 (defn build-sub-map
-  [args]
+  [sub-fn args]
   (let [[op f]
         (take-last 2 args)
 
@@ -100,8 +100,8 @@
           2 (let [[sugar signal] input-args]
               (if (and (= :<- sugar) (vector? signal))
                 (fn input-fn
-                  ([_] (subscribe signal))
-                  ([_ _] (subscribe signal)))
+                  ([_] (sub-fn signal))
+                  ([_ _] (sub-fn signal)))
                 (throw (Exception. (str "Expected pairs of `:<-` and vectors, got: " input-args)))))
           ;; else
           (let [pairs (partition 2 input-args)
@@ -109,8 +109,8 @@
                 signals (map second pairs)]
             (if (and (every? #{:<-} sugars) (every? vector? signals))
               (fn input-fn
-                ([_] (map subscribe signals))
-                ([_ _] (map subscribe signals)))
+                ([_] (map sub-fn signals))
+                ([_ _] (map sub-fn signals)))
               (throw (Exception. (str "Expected pairs of `:<-` and vectors, got: " input-args))))))]
     {:signal-fn signal-fn
      :computation-fn computation-fn}))
@@ -150,7 +150,7 @@
   See also: `subscribe`
   "
   [subscription-id & args]
-  (swap! subscriptions assoc subscription-id (build-sub-map args)))
+  (swap! subscriptions assoc subscription-id (build-sub-map subscribe args)))
 
 ;; Effects
 

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -85,20 +85,27 @@
               :-> [input-args
                    (fn [signals _] (f signals))]
               :=> [input-args
-                   (fn [signals [_ & opts]] (apply f signals opts))])))
+                   (fn [signals [_ & opts]] (apply f signals opts))]
+              (throw (Exception. (str "Expected `:->` or `:=>` as second-to-last argument, got: " op))))))
 
         signal-fn
         (case (count input-args)
           0 (fn app-db-subscription
               ([_] app-db)
               ([_ _] app-db))
-          1 (first input-args)
+          1 (let [input-fn (first input-args)]
+              (if (fn? input-fn)
+                input-fn
+                (throw (Exception. (str "Expected 2nd argument to be input function, got: " input-fn)))))
           ;; else
           (let [pairs (partition 2 input-args)
+                sugars (map first pairs)
                 signals (map second pairs)]
-            (fn input-fn
-              ([_] (map subscribe vecs))
-              ([_ _] (map subscribe vecs)))))]
+            (if (and (every? #{:<-} sugars) (every? vector? signals))
+              (fn input-fn
+                ([_] (map subscribe signals))
+                ([_ _] (map subscribe signals)))
+              (throw (Exception. (str "Expected pairs of `:<-` and vectors, got: " pairs))))))]
     {:signal-fn signal-fn
      :computation-fn computation-fn}))
 

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -128,21 +128,16 @@
   "
   [query-vec]
   (let [subscription-id (first query-vec)]
-    (if-let [{:keys [extractor-fn signal-fn computation-fn]} (subscription-id @subscriptions)]
-      (if extractor-fn
-
-        ;; extract derived value from app-db
-        (f/$ (extractor-fn (f/<! app-db) query-vec))
-
-        ;; signal from other subscriptions
-        (f/$ (computation-fn (let [signals (signal-fn query-vec)]
-                               (cond
-                                 (vector? signals) (map #(f/<! %) signals)
-                                 (map? signals)    (map->signals signals)
-                                 :else             (f/<! signals)))
-                             query-vec)))
+    (if-let [{:keys [signal-fn computation-fn]}
+             (get @subscriptions subscription-id)]
+      (f/$ (computation-fn
+            (let [signals (signal-fn query-vec)]
+              (cond
+                (vector? signals) (map #(f/<! %) signals)
+                (map? signals)    (map->signals signals)
+                :else             (f/<! signals)))
+            query-vec))
       (throw (Exception. (str "Subscription not found: " subscription-id))))))
-
 
 ;; Effects
 

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -135,14 +135,14 @@
 
           #!clj
           ;; equivalent to (reg-sub :query-id (fn [db _] (:foo db)))
-          ;; (subscribe :query-id)
+          ;; (subscribe [:query-id])
           (reg-sub
             :query-id
             :-> :foo))
 
           #!clj
           ;; equivalent to (reg-sub :query-id (fn [db [_ & opts]] (apply get-in db opts)))
-          ;; (subscribe :query-id [:foo :bar])
+          ;; (subscribe [:query-id [[:foo :bar]]])
           (reg-sub
             :query-id
             :=> get-in)

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -36,6 +36,13 @@
    (swap! subscriptions assoc subscription-id {:signal-fn signal-fn
                                                :computation-fn computation-fn})))
 
+(defn- map->signals
+  [signals]
+  (->> (map (fn [[k v]]
+              {k (f/<! v)})
+            signals)
+       (into {})))
+
 (defn subscribe
   "Subscribe to derived state, internally using ClojureDart Cells (see the [Cheatsheet](https://github.com/Tensegritics/ClojureDart/blob/main/doc/ClojureDart%20Cheatsheet.pdf))
 
@@ -78,7 +85,12 @@
         (f/$ (extractor-fn (f/<! app-db) query-vec))
 
         ;; signal from other subscriptions
-        (f/$ (computation-fn (f/<! (signal-fn query-vec)) query-vec)))
+        (f/$ (computation-fn (let [signals (signal-fn query-vec)]
+                               (cond
+                                 (vector? signals) (map #(f/<! %) signals)
+                                 (map? signals)    (map->signals signals)
+                                 :else             (f/<! signals)))
+                             query-vec)))
       (throw (Exception. (str "Subscription not found: " subscription-id))))))
 
 

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -111,7 +111,7 @@
               (fn input-fn
                 ([_] (map subscribe signals))
                 ([_ _] (map subscribe signals)))
-              (throw (Exception. (str "Expected pairs of `:<-` and vectors, got: " pairs))))))]
+              (throw (Exception. (str "Expected pairs of `:<-` and vectors, got: " input-args))))))]
     {:signal-fn signal-fn
      :computation-fn computation-fn}))
 

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -12,16 +12,42 @@
 
 (defonce ^:private subscriptions (atom {}))
 
-(defn computation-fn
+(defn build-sub-map
   [args]
-  (let [[op f] (take-last 2 args)]
-    (if (nil? f)
-      ;; (reg-sub ::foo (fn [_ _]))
-      op
-      ;; (reg-sub ::foo :-> :foo)
-      (case op
-        :-> (fn [db _] (f db))
-        :=> (fn [db [_ & opts]] (apply f db opts))))))
+  (let [[op f]
+        (take-last 2 args)
+
+        [input-args computation-fn]
+        (if (or
+             ;; (reg-sub ::foo (fn [_ _]))
+             (nil? f)
+             ;; (reg-sub ::foo (fn [_ _]) (fn [_ _])) ;; input fn
+             (fn? op)
+             ;; (reg-sub ::foo :<- [::bar] (fn [_ _]))) ;; input sugar
+             (vector? op))
+          [(butlast args) (last args)]
+          ;; (reg-sub ::foo ,,, :-> :foo)
+          (let [input-args (drop-last 2 args)]
+            (case op
+              :-> [input-args
+                   (fn [signals _] (f signals))]
+              :=> [input-args
+                   (fn [signals [_ & opts]] (apply f signals opts))])))
+
+        signal-fn
+        (case (count input-args)
+          0 (fn app-db-subscription
+              ([_] app-db)
+              ([_ _] app-db))
+          1 (first input-args)
+          ;; else
+          (let [pairs (partition 2 input-args)
+                signals (map second pairs)]
+            (fn input-fn
+              ([_] (map subscribe vecs))
+              ([_ _] (map subscribe vecs)))))]
+    {:signal-fn signal-fn
+     :computation-fn computation-fn}))
 
 (defn reg-sub
   "A call to `reg-sub` associates a `query-id` with one function.
@@ -58,7 +84,7 @@
   See also: `subscribe`
   "
   [subscription-id & args]
-  (swap! subscriptions assoc subscription-id (computation-fn args)))
+  (swap! subscriptions assoc subscription-id (build-sub-map args)))
 
 (defn- map->signals
   [signals]

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -12,6 +12,59 @@
 
 (defonce ^:private subscriptions (atom {}))
 
+(defn- map->signals
+  [signals]
+  (->> (map (fn [[k v]]
+              {k (f/<! v)})
+            signals)
+       (into {})))
+
+(defn subscribe
+  "Subscribe to derived state, internally using ClojureDart Cells (see the [Cheatsheet](https://github.com/Tensegritics/ClojureDart/blob/main/doc/ClojureDart%20Cheatsheet.pdf))
+
+  Given a `query` vector it will, over
+  time, reactively deliver a stream of values. So, in FRP-ish terms,
+  it returns a `Signal`.
+
+  To obtain the current value from the Signal, it must be dereferenced via `:watch`:
+
+      #!clj
+      (f/widget
+       :watch [current-count (subscribe [::model/get-count])]
+       (m/Text (str current-count)))
+
+
+  `query` is a vector of at least one element. The first element is the
+  `query-id`, typically a namespaced keyword. The rest of the vector's
+  elements are optional, additional values which parameterise the query
+  performed.
+
+  **Example Usage**:
+
+      #!clj
+      (subscribe [:items])
+      (subscribe [:items \"blue\" :small])
+      (subscribe [:items {:colour \"blue\"  :size :small}])
+
+  Note: for any given call to `subscribe` there must have been a previous call
+  to `reg-sub`, registering the query handler (functions) associated with
+  `query-id`.
+
+  See also: `reg-sub`
+  "
+  [query-vec]
+  (let [subscription-id (first query-vec)]
+    (if-let [{:keys [signal-fn computation-fn]}
+             (get @subscriptions subscription-id)]
+      (f/$ (computation-fn
+            (let [signals (signal-fn query-vec)]
+              (cond
+                (vector? signals) (map #(f/<! %) signals)
+                (map? signals)    (map->signals signals)
+                :else             (f/<! signals)))
+            query-vec))
+      (throw (Exception. (str "Subscription not found: " subscription-id))))))
+
 (defn build-sub-map
   [args]
   (let [[op f]
@@ -85,59 +138,6 @@
   "
   [subscription-id & args]
   (swap! subscriptions assoc subscription-id (build-sub-map args)))
-
-(defn- map->signals
-  [signals]
-  (->> (map (fn [[k v]]
-              {k (f/<! v)})
-            signals)
-       (into {})))
-
-(defn subscribe
-  "Subscribe to derived state, internally using ClojureDart Cells (see the [Cheatsheet](https://github.com/Tensegritics/ClojureDart/blob/main/doc/ClojureDart%20Cheatsheet.pdf))
-
-  Given a `query` vector it will, over
-  time, reactively deliver a stream of values. So, in FRP-ish terms,
-  it returns a `Signal`.
-
-  To obtain the current value from the Signal, it must be dereferenced via `:watch`:
-
-      #!clj
-      (f/widget
-       :watch [current-count (subscribe [::model/get-count])]
-       (m/Text (str current-count)))
-
-
-  `query` is a vector of at least one element. The first element is the
-  `query-id`, typically a namespaced keyword. The rest of the vector's
-  elements are optional, additional values which parameterise the query
-  performed.
-
-  **Example Usage**:
-
-      #!clj
-      (subscribe [:items])
-      (subscribe [:items \"blue\" :small])
-      (subscribe [:items {:colour \"blue\"  :size :small}])
-
-  Note: for any given call to `subscribe` there must have been a previous call
-  to `reg-sub`, registering the query handler (functions) associated with
-  `query-id`.
-
-  See also: `reg-sub`
-  "
-  [query-vec]
-  (let [subscription-id (first query-vec)]
-    (if-let [{:keys [signal-fn computation-fn]}
-             (get @subscriptions subscription-id)]
-      (f/$ (computation-fn
-            (let [signals (signal-fn query-vec)]
-              (cond
-                (vector? signals) (map #(f/<! %) signals)
-                (map? signals)    (map->signals signals)
-                :else             (f/<! signals)))
-            query-vec))
-      (throw (Exception. (str "Subscription not found: " subscription-id))))))
 
 ;; Effects
 

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -97,6 +97,12 @@
               (if (fn? input-fn)
                 input-fn
                 (throw (Exception. (str "Expected 2nd argument to be input function, got: " input-fn)))))
+          2 (let [[sugar signal] input-args]
+              (if (and (= :<- sugar) (vector? signal))
+                (fn input-fn
+                  ([_] (subscribe signal))
+                  ([_ _] (subscribe signal)))
+                (throw (Exception. (str "Expected pairs of `:<-` and vectors, got: " input-args)))))
           ;; else
           (let [pairs (partition 2 input-args)
                 sugars (map first pairs)

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -30,8 +30,11 @@
 
   See also: `subscribe`
   "
-  [subscription-id f]
-  (swap! subscriptions assoc subscription-id f))
+  ([subscription-id extractor-fn]
+   (swap! subscriptions assoc subscription-id {:extractor-fn extractor-fn}))
+  ([subscription-id signal-fn computation-fn]
+   (swap! subscriptions assoc subscription-id {:signal-fn signal-fn
+                                               :computation-fn computation-fn})))
 
 (defn subscribe
   "Subscribe to derived state, internally using ClojureDart Cells (see the [Cheatsheet](https://github.com/Tensegritics/ClojureDart/blob/main/doc/ClojureDart%20Cheatsheet.pdf))
@@ -68,8 +71,14 @@
   "
   [query-vec]
   (let [subscription-id (first query-vec)]
-    (if-let [subscription-fn (subscription-id @subscriptions)]
-      (f/$ (subscription-fn (f/<! app-db) query-vec))
+    (if-let [{:keys [extractor-fn signal-fn computation-fn]} (subscription-id @subscriptions)]
+      (if extractor-fn
+
+        ;; extract derived value from app-db
+        (f/$ (extractor-fn (f/<! app-db) query-vec))
+
+        ;; signal from other subscriptions
+        (f/$ (computation-fn (f/<! (signal-fn query-vec)) query-vec)))
       (throw (Exception. (str "Subscription not found: " subscription-id))))))
 
 

--- a/test/hti/re_dash_test.cljd
+++ b/test/hti/re_dash_test.cljd
@@ -46,6 +46,11 @@
         (let [comp-fn #()]
           (is (= {:signal-fn input-fn :computation-fn comp-fn}
                  (build-sub-map dummy-subscribe (list input-fn comp-fn))))))
+      (testing "Bad input"
+        (is (thrown? Exception
+                     (build-sub-map dummy-subscribe
+                                    (list 42 (fn [_ _]))))
+            "Raises if input function is not a function"))
       (testing ":-> sugar"
         ;; (reg-sub ::foo (fn [_ _]) :-> :baz)
         (let [coords [::foo]
@@ -61,7 +66,14 @@
                dummy-subscribe
                (list input-fn :=> (fn [a b] (or a (* 2 b)))))]
           (is (= input-fn signal-fn))
-          (is (= 84 (computation-fn @(signal-fn coords) coords)))))))
+          (is (= 84 (computation-fn @(signal-fn coords) coords)))))
+      (testing "Bad sugar"
+        ;; (reg-sub ::foo (fn [_ _]) :/> (fn [_ _]))
+        (is (thrown? Exception
+                     (build-sub-map
+                      dummy-subscribe
+                      (list input-fn :invalid> (fn [_ _]))))
+            "Raises on unknown syntax sugar"))))
   (testing "No input function"
     (testing "Just computation function"
       ;; (reg-sub ::foo (fn [_ _]))
@@ -84,7 +96,14 @@
             (build-sub-map
              dummy-subscribe
              (list :=> (fn [db a b] {(b db) (a db)})))]
-        (is (= {9001 {:bar 42}} (computation-fn @(signal-fn coords) coords))))))
+        (is (= {9001 {:bar 42}} (computation-fn @(signal-fn coords) coords)))))
+    (testing "Bad sugar"
+      ;; (reg-sub ::foo :/> (fn [_ _]))
+      (is (thrown? Exception
+                   (build-sub-map
+                    dummy-subscribe
+                    (list :invalid> (fn [_ _]))))
+          "Raises on unknown syntax sugar")))
   (testing "One sugar input pair"
     (testing "Computation function"
       ;; (reg-sub ::foo :<- [::hoge] (fn [n _] n))
@@ -94,6 +113,18 @@
             (build-sub-map dummy-subscribe (list :<- [::hoge] comp-fn))]
         (is (= 42 @(signal-fn coords)))
         (is (= comp-fn computation-fn))))
+    (testing "Bad input sugar"
+      (is (thrown? Exception
+                   (build-sub-map
+                    dummy-subscribe
+                    (list :<invalid [::hoge] (fn [_ _]))))
+          "Raises on unknown syntax sugar"))
+    (testing "Missing subscription"
+      (let [coords [::foo]
+            {:keys [computation-fn signal-fn]}
+            (build-sub-map dummy-subscribe (list :<- [::piyo] (fn [_ _])))]
+        (is (thrown? Exception (computation-fn @(signal-fn coords) coords))
+            "If the subscription used as input isn't registered, raises when subscribed to")))
     (testing ":-> sugar"
       ;; (reg-sub ::foo :<- [::hoge] :-> (fn [n _] (* 2 n)))
       (let [coords [::foo 2]
@@ -113,7 +144,13 @@
              dummy-subscribe
              (list :<- [::hoge] :=> (fn [db a b] [db a b])))]
         (is (= 42 @(signal-fn coords)))
-        (is (= [42 :hoge :fuga] (computation-fn @(signal-fn coords) coords))))))
+        (is (= [42 :hoge :fuga] (computation-fn @(signal-fn coords) coords)))))
+    (testing "Bad output sugar"
+      (is (thrown? Exception
+                   (build-sub-map
+                    dummy-subscribe
+                    (list :<- [::hoge] :invalid> (fn [_ _]))))
+          "Raises on unknown syntax sugar")))
   (testing "Multiple sugar pairs"
     (testing "Computation function"
       ;; (reg-sub ::foo :<- [::hoge] :<- [::fuga] (fn [n _] n))
@@ -125,6 +162,41 @@
              (list :<- [::hoge] :<- [::fuga] comp-fn))]
         (is (= (list 42 9001) (map deref (signal-fn coords))))
         (is (= comp-fn computation-fn))))
+    (testing "Bad input sugar"
+      (is (thrown? Exception
+                   (build-sub-map
+                    dummy-subscribe
+                    (list :<- [::hoge] :<invalid [::fuga] (fn [_ _]))))
+          "Raises on unknown syntax sugar")
+      (is (thrown? Exception
+                   (build-sub-map
+                    dummy-subscribe
+                    (list :<invalid [::hoge] :<- [::fuga] (fn [_ _]))))
+          "Raises on unknown syntax sugar")
+      (is (thrown? Exception
+                   (build-sub-map
+                    dummy-subscribe
+                    (list :<invalid [::hoge] :<invalid [::fuga] (fn [_ _]))))
+          "Raises on unknown syntax sugar"))
+    (testing "Missing subscription"
+      (let [coords [::foo]
+            {:keys [computation-fn signal-fn]}
+            (build-sub-map dummy-subscribe
+                           (list :<- [::piyo] :<- [::hoge] (fn [_ _])))]
+        (is (thrown? Exception (computation-fn @(signal-fn coords) coords))
+            "If the subscription used as input isn't registered, raises when subscribed to"))
+      (let [coords [::foo]
+            {:keys [computation-fn signal-fn]}
+            (build-sub-map dummy-subscribe
+                           (list :<- [::hoge] :<- [::piyo] (fn [_ _])))]
+        (is (thrown? Exception (computation-fn @(signal-fn coords) coords))
+            "If the subscription used as input isn't registered, raises when subscribed to"))
+      (let [coords [::foo]
+            {:keys [computation-fn signal-fn]}
+            (build-sub-map dummy-subscribe
+                           (list :<- [::piyo] :<- [::puyo] (fn [_ _])))]
+        (is (thrown? Exception (computation-fn @(signal-fn coords) coords))
+            "If the subscription used as input isn't registered, raises when subscribed to")))
     (testing ":-> sugar"
       ;; (reg-sub ::foo :<- [::hoge] :<- [::fuga] :-> (fn [n] (* 2 n)))
       (let [coords [::foo 2]
@@ -144,4 +216,10 @@
              (list :<- [::hoge] :<- [::fuga] :=> (fn [[_ x] a b] [x a b])))]
         (is (= (list 42 9001) (map deref (signal-fn coords))))
         (is (= [9001 :hoge :fuga]
-               (computation-fn (map deref (signal-fn coords)) coords)))))))
+               (computation-fn (map deref (signal-fn coords)) coords)))))
+    (testing "Bad output sugar"
+      (is (thrown? Exception
+                   (build-sub-map
+                    dummy-subscribe
+                    (list :<- [::hoge] :<- [::fuga] :invalid> (fn [_ _]))))
+          "Raises on unknown syntax sugar"))))

--- a/test/hti/re_dash_test.cljd
+++ b/test/hti/re_dash_test.cljd
@@ -1,12 +1,134 @@
 (ns hti.re-dash-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [cljd.flutter :as f]
             [hti.re-dash :refer [build-sub-map]]))
 
+(defn reset-app-db
+  ([] (reset! hti.re-dash/app-db {:foo {:bar 42} :baz 9001}))
+  ([_] (reset! hti.re-dash/app-db {})))
+
+(defn reset-subscriptions
+  ;; (reg-sub ::hoge (fn [_ _] 42))
+  ;; (reg-sub ::fuga (fn [_ _] 9001))
+  ([] (reset! hti.re-dash/subscriptions
+              {::hoge {:signal-fn (constantly hti.re-dash/app-db)
+                       :computation-fn (constantly 42)}
+               ::fuga {:signal-fn (constantly hti.re-dash/app-db)
+                       :computation-fn (constantly 9001)}}))
+  ([_] (reset! hti.re-dash/subscriptions {})))
+
+;; ideally :each but that doesn't seem to work yet
+(use-fixtures :once reset-app-db reset-subscriptions)
+; (use-fictures :each reset-app-db reset-subscriptions)
+
 (deftest build-sub-map-test
-  (binding [hti.re-dash/app-db (atom {:foo {:bar 42} :baz 9001})]
-    (testing "Two functions case"
-      ;; (reg-sub ::foo (fn [_ _]) (fn [_ _]))
-      (let [input-fn #()
-            comp-fn #()]
-        (is (= {:signal-fn input-fn :computation-fn comp-fn}
-               (build-sub-map (list input-fn comp-fn))))))))
+  (testing "Explicit input function"
+    ;; TODO use <! instead of deref and that should endure (fn ([_]) ([_ _]))
+    (let [input-fn (constantly (atom nil))]
+      (testing "Just computation function"
+        ;; (reg-sub ::foo (fn [_ _]) (fn [_ _]))
+        (let [comp-fn #()]
+          (is (= {:signal-fn input-fn :computation-fn comp-fn}
+                 (build-sub-map (list input-fn comp-fn))))))
+      (testing ":-> sugar"
+        ;; (reg-sub ::foo (fn [_ _]) :-> :baz)
+        (let [coords [::foo]
+              {:keys [signal-fn computation-fn]}
+              (build-sub-map (list input-fn :-> nil?))]
+          (is (= input-fn signal-fn))
+          (is (= true (computation-fn @(signal-fn coords) coords)))))
+      (testing ":=> sugar"
+        ;; (reg-sub ::foo (fn [_ _]) :=> (fn [a b] (or a b)))
+        (let [coords [::foo 42]
+              {:keys [signal-fn computation-fn]}
+              (build-sub-map (list input-fn :=> (fn [a b] (or a (* 2 b)))))]
+          (is (= input-fn signal-fn))
+          (is (= 84 (computation-fn @(signal-fn coords) coords)))))))
+  (testing "No input function"
+    (testing "Just computation function"
+      ;; (reg-sub ::foo (fn [_ _]))
+      (let [comp-fn #()
+            {:keys [signal-fn computation-fn]}
+            (build-sub-map (list comp-fn))]
+        ;; TODO use <! like in subscribe
+        (is (= 9001 (:baz @(signal-fn [])))
+            "The signal becomes the default app-db")
+        (is (= comp-fn computation-fn))))
+    (testing ":-> sugar"
+      ;; (reg-sub ::foo :-> :baz)
+      (let [coords [::foo]
+            {:keys [signal-fn computation-fn]}
+            (build-sub-map (list :-> :baz))]
+        ;; TODO use <! like in subscribe
+        (is (= 9001 (computation-fn @(signal-fn coords) coords)))))
+    (testing ":=> sugar"
+      ;; (reg-sub ::foo :=> get-in)
+      (let [coords [::foo :foo :baz]
+            {:keys [signal-fn computation-fn]}
+            (build-sub-map (list :=> (fn [db a b] {(b db) (a db)})))]
+        ;; TODO use <! like in subscribe
+        (is (= {9001 {:bar 42}} (computation-fn @(signal-fn coords) coords))))))
+  (testing "One sugar input pair"
+    (testing "Computation function"
+      ;; (reg-sub ::foo :<- [::hoge] (fn [n _] n))
+      (let [coords [::foo]
+            comp-fn (fn [n _] n)
+            {:keys [signal-fn computation-fn]}
+            (build-sub-map (list :<- [::hoge] comp-fn))]
+        ;; TODO somehow deref Cell to check value
+        (is (instance? f/Cell (signal-fn coords)))
+        (is (= comp-fn computation-fn))))
+    (testing ":-> sugar"
+      ;; (reg-sub ::foo :<- [::hoge] :-> (fn [n _] (* 2 n)))
+      (let [coords [::foo 2]
+            {:keys [signal-fn computation-fn]}
+            (build-sub-map (list :<- [::hoge] :-> (fn [n] (* 2 n))))]
+        ;; TODO somehow deref Cell to check value
+        (is (instance? f/Cell (signal-fn coords)))
+        ;; TODO use <! like in subscribe
+        (is (= 84 (computation-fn 42 coords))
+            "the subscription params are ignored with :->")))
+    (testing ":=> sugar"
+      ;; (reg-sub ::foo :<- [::hoge] :=> (fn [db a b] [db a b]))
+      (let [coords [::foo :hoge :fuga]
+            {:keys [signal-fn computation-fn]}
+            (build-sub-map (list :<- [::hoge] :=> (fn [db a b] [db a b])))]
+        ;; TODO somehow deref Cell to check value
+        (is (instance? f/Cell (signal-fn coords)))
+        ;; TODO use <! like in subscribe
+        (is (= [42 :hoge :fuga] (computation-fn 42 coords))))))
+  (testing "Multiple sugar pairs"
+    (testing "Computation function"
+      ;; (reg-sub ::foo :<- [::hoge] :<- [::fuga] (fn [n _] n))
+      (let [coords [::foo]
+            comp-fn (fn [inputs _] inputs)
+            {:keys [signal-fn computation-fn]}
+            (build-sub-map (list :<- [::hoge] :<- [::fuga] comp-fn))]
+        ;; TODO somehow deref Cells to check value
+        (is (seq? (signal-fn coords)))
+        (is (= 2 (count (signal-fn coords))))
+        (is (every? #(dart/is? % f/Cell) (signal-fn coords)))
+        (is (= comp-fn computation-fn))))
+    (testing ":-> sugar"
+      ;; (reg-sub ::foo :<- [::hoge] :<- [::fuga] :-> (fn [n] (* 2 n)))
+      (let [coords [::foo 2]
+            {:keys [signal-fn computation-fn]}
+            (build-sub-map (list :<- [::hoge] :<- [::fuga] :-> (fn [[n _]] (* 2 n))))]
+        ;; TODO somehow deref Cells to check value
+        (is (seq? (signal-fn coords)))
+        (is (= 2 (count (signal-fn coords))))
+        (is (every? #(dart/is? % f/Cell) (signal-fn coords)))
+        ;; TODO use <! like in subscribe
+        (is (= 84 (computation-fn (list 42 9001) coords))
+            "the subscription params are ignored with :->")))
+    (testing ":=> sugar"
+      ;; (reg-sub ::foo :<- [::hoge] :<- [::fuga] :=> (fn [[_ x] a b] [x a b]))
+      (let [coords [::foo :hoge :fuga]
+            {:keys [signal-fn computation-fn]}
+            (build-sub-map (list :<- [::hoge] :<- [::fuga] :=> (fn [[_ x] a b] [x a b])))]
+        ;; TODO somehow deref Cells to check value
+        (is (seq? (signal-fn coords)))
+        (is (= 2 (count (signal-fn coords))))
+        (is (every? #(dart/is? % f/Cell) (signal-fn coords)))
+        ;; TODO use <! like in subscribe
+        (is (= [9001 :hoge :fuga] (computation-fn (list 42 9001) coords)))))))

--- a/test/hti/re_dash_test.cljd
+++ b/test/hti/re_dash_test.cljd
@@ -1,16 +1,12 @@
 (ns hti.re-dash-test
   (:require [clojure.test :refer [deftest is testing]]
-            [hti.re-dash :refer [computation-fn]]))
+            [hti.re-dash :refer [build-sub-map]]))
 
-(deftest some-test
-  (is (= 1 1)))
-
-#_(deftest computation-fn-test
-  (let [db {:foo 42
-            :bar {:baz 9001}}]
-    (testing ":->"
-      (let [f (computation-fn (list :-> :foo))]
-        (is (= 42 (f db [])))))
-    (testing ":=>"
-      (let [f (computation-fn (list :=> get-in))]
-        (is (= 9001 (f db [:bar :baz])))))))
+(deftest build-sub-map-test
+  (binding [hti.re-dash/app-db (atom {:foo {:bar 42} :baz 9001})]
+    (testing "Two functions case"
+      ;; (reg-sub ::foo (fn [_ _]) (fn [_ _]))
+      (let [input-fn #()
+            comp-fn #()]
+        (is (= {:signal-fn input-fn :computation-fn comp-fn}
+               (build-sub-map (list input-fn comp-fn))))))))

--- a/test/hti/re_dash_test.cljd
+++ b/test/hti/re_dash_test.cljd
@@ -21,27 +21,45 @@
 (use-fixtures :once reset-app-db reset-subscriptions)
 ; (use-fictures :each reset-app-db reset-subscriptions)
 
+(defn dummy-subscribe
+  [[sub-id :as query-vec]]
+  (if-let [{:keys [signal-fn computation-fn]}
+           (get @hti.re-dash/subscriptions sub-id)]
+    (atom (computation-fn
+           (let [signals (signal-fn query-vec)]
+             (cond
+               (vector? signals) (map deref signals)
+               (map? signals)    (reduce-kv
+                                  (fn [aggr k v] (assoc aggr k (deref v)))
+                                  {}
+                                  signals)
+               :else             (deref signals)))
+           query-vec))
+    (throw (Exception. (str "Missing dummy sub: " sub-id)))))
+
 (deftest build-sub-map-test
   (testing "Explicit input function"
-    ;; TODO use <! instead of deref and that should endure (fn ([_]) ([_ _]))
-    (let [input-fn (constantly (atom nil))]
+    (let [dummy-state (atom nil)
+          input-fn (fn dummy-input ([] dummy-state) ([_] dummy-state))]
       (testing "Just computation function"
         ;; (reg-sub ::foo (fn [_ _]) (fn [_ _]))
         (let [comp-fn #()]
           (is (= {:signal-fn input-fn :computation-fn comp-fn}
-                 (build-sub-map (list input-fn comp-fn))))))
+                 (build-sub-map dummy-subscribe (list input-fn comp-fn))))))
       (testing ":-> sugar"
         ;; (reg-sub ::foo (fn [_ _]) :-> :baz)
         (let [coords [::foo]
               {:keys [signal-fn computation-fn]}
-              (build-sub-map (list input-fn :-> nil?))]
+              (build-sub-map dummy-subscribe (list input-fn :-> nil?))]
           (is (= input-fn signal-fn))
           (is (= true (computation-fn @(signal-fn coords) coords)))))
       (testing ":=> sugar"
         ;; (reg-sub ::foo (fn [_ _]) :=> (fn [a b] (or a b)))
         (let [coords [::foo 42]
               {:keys [signal-fn computation-fn]}
-              (build-sub-map (list input-fn :=> (fn [a b] (or a (* 2 b)))))]
+              (build-sub-map
+               dummy-subscribe
+               (list input-fn :=> (fn [a b] (or a (* 2 b)))))]
           (is (= input-fn signal-fn))
           (is (= 84 (computation-fn @(signal-fn coords) coords)))))))
   (testing "No input function"
@@ -49,8 +67,7 @@
       ;; (reg-sub ::foo (fn [_ _]))
       (let [comp-fn #()
             {:keys [signal-fn computation-fn]}
-            (build-sub-map (list comp-fn))]
-        ;; TODO use <! like in subscribe
+            (build-sub-map dummy-subscribe (list comp-fn))]
         (is (= 9001 (:baz @(signal-fn [])))
             "The signal becomes the default app-db")
         (is (= comp-fn computation-fn))))
@@ -58,15 +75,15 @@
       ;; (reg-sub ::foo :-> :baz)
       (let [coords [::foo]
             {:keys [signal-fn computation-fn]}
-            (build-sub-map (list :-> :baz))]
-        ;; TODO use <! like in subscribe
+            (build-sub-map dummy-subscribe (list :-> :baz))]
         (is (= 9001 (computation-fn @(signal-fn coords) coords)))))
     (testing ":=> sugar"
       ;; (reg-sub ::foo :=> get-in)
       (let [coords [::foo :foo :baz]
             {:keys [signal-fn computation-fn]}
-            (build-sub-map (list :=> (fn [db a b] {(b db) (a db)})))]
-        ;; TODO use <! like in subscribe
+            (build-sub-map
+             dummy-subscribe
+             (list :=> (fn [db a b] {(b db) (a db)})))]
         (is (= {9001 {:bar 42}} (computation-fn @(signal-fn coords) coords))))))
   (testing "One sugar input pair"
     (testing "Computation function"
@@ -74,61 +91,57 @@
       (let [coords [::foo]
             comp-fn (fn [n _] n)
             {:keys [signal-fn computation-fn]}
-            (build-sub-map (list :<- [::hoge] comp-fn))]
-        ;; TODO somehow deref Cell to check value
-        (is (instance? f/Cell (signal-fn coords)))
+            (build-sub-map dummy-subscribe (list :<- [::hoge] comp-fn))]
+        (is (= 42 @(signal-fn coords)))
         (is (= comp-fn computation-fn))))
     (testing ":-> sugar"
       ;; (reg-sub ::foo :<- [::hoge] :-> (fn [n _] (* 2 n)))
       (let [coords [::foo 2]
             {:keys [signal-fn computation-fn]}
-            (build-sub-map (list :<- [::hoge] :-> (fn [n] (* 2 n))))]
+            (build-sub-map
+             dummy-subscribe
+             (list :<- [::hoge] :-> (fn [n] (* 2 n))))]
         ;; TODO somehow deref Cell to check value
-        (is (instance? f/Cell (signal-fn coords)))
-        ;; TODO use <! like in subscribe
-        (is (= 84 (computation-fn 42 coords))
+        (is (= 42 @(signal-fn coords)))
+        (is (= 84 (computation-fn @(signal-fn coords) coords))
             "the subscription params are ignored with :->")))
     (testing ":=> sugar"
       ;; (reg-sub ::foo :<- [::hoge] :=> (fn [db a b] [db a b]))
       (let [coords [::foo :hoge :fuga]
             {:keys [signal-fn computation-fn]}
-            (build-sub-map (list :<- [::hoge] :=> (fn [db a b] [db a b])))]
-        ;; TODO somehow deref Cell to check value
-        (is (instance? f/Cell (signal-fn coords)))
-        ;; TODO use <! like in subscribe
-        (is (= [42 :hoge :fuga] (computation-fn 42 coords))))))
+            (build-sub-map
+             dummy-subscribe
+             (list :<- [::hoge] :=> (fn [db a b] [db a b])))]
+        (is (= 42 @(signal-fn coords)))
+        (is (= [42 :hoge :fuga] (computation-fn @(signal-fn coords) coords))))))
   (testing "Multiple sugar pairs"
     (testing "Computation function"
       ;; (reg-sub ::foo :<- [::hoge] :<- [::fuga] (fn [n _] n))
       (let [coords [::foo]
             comp-fn (fn [inputs _] inputs)
             {:keys [signal-fn computation-fn]}
-            (build-sub-map (list :<- [::hoge] :<- [::fuga] comp-fn))]
-        ;; TODO somehow deref Cells to check value
-        (is (seq? (signal-fn coords)))
-        (is (= 2 (count (signal-fn coords))))
-        (is (every? #(dart/is? % f/Cell) (signal-fn coords)))
+            (build-sub-map
+             dummy-subscribe
+             (list :<- [::hoge] :<- [::fuga] comp-fn))]
+        (is (= (list 42 9001) (map deref (signal-fn coords))))
         (is (= comp-fn computation-fn))))
     (testing ":-> sugar"
       ;; (reg-sub ::foo :<- [::hoge] :<- [::fuga] :-> (fn [n] (* 2 n)))
       (let [coords [::foo 2]
             {:keys [signal-fn computation-fn]}
-            (build-sub-map (list :<- [::hoge] :<- [::fuga] :-> (fn [[n _]] (* 2 n))))]
-        ;; TODO somehow deref Cells to check value
-        (is (seq? (signal-fn coords)))
-        (is (= 2 (count (signal-fn coords))))
-        (is (every? #(dart/is? % f/Cell) (signal-fn coords)))
-        ;; TODO use <! like in subscribe
-        (is (= 84 (computation-fn (list 42 9001) coords))
+            (build-sub-map
+             dummy-subscribe
+             (list :<- [::hoge] :<- [::fuga] :-> (fn [[n _]] (* 2 n))))]
+        (is (= (list 42 9001) (map deref (signal-fn coords))))
+        (is (= 84 (computation-fn (map deref (signal-fn coords)) coords))
             "the subscription params are ignored with :->")))
     (testing ":=> sugar"
       ;; (reg-sub ::foo :<- [::hoge] :<- [::fuga] :=> (fn [[_ x] a b] [x a b]))
       (let [coords [::foo :hoge :fuga]
             {:keys [signal-fn computation-fn]}
-            (build-sub-map (list :<- [::hoge] :<- [::fuga] :=> (fn [[_ x] a b] [x a b])))]
-        ;; TODO somehow deref Cells to check value
-        (is (seq? (signal-fn coords)))
-        (is (= 2 (count (signal-fn coords))))
-        (is (every? #(dart/is? % f/Cell) (signal-fn coords)))
-        ;; TODO use <! like in subscribe
-        (is (= [9001 :hoge :fuga] (computation-fn (list 42 9001) coords)))))))
+            (build-sub-map
+             dummy-subscribe
+             (list :<- [::hoge] :<- [::fuga] :=> (fn [[_ x] a b] [x a b])))]
+        (is (= (list 42 9001) (map deref (signal-fn coords))))
+        (is (= [9001 :hoge :fuga]
+               (computation-fn (map deref (signal-fn coords)) coords)))))))


### PR DESCRIPTION
Resolves #2 

## Input signals
- [x] explicit function
- [x] implicit app-db
- [x] one pair of `:<- [::sub-name]` sugar
- [x] multiple pairs of sugar

## Computation function
- [x] explicit function
- [x] `:->` sugar (ignores subscription params, only depends on input signals)
  `(fn [db _] (:foo db))` => `:-> :foo`
- [x] `:=>` sugar (flattens the params and removes sub name)
  `(fn [db [_ x y]] (+ x y))` ⇨ `:=> (fn [db x y] (+ x y))`

## Tests
```shell
clj -M:cljd:test compile hti.re-dash-test && flutter test
```

- [x] happy path
- [ ] reset state between each test case (since the tests are read-only and don't alter the state it doesn't really matter)
- [x] actual values from derived subscriptions (can't seem to get the value of a Cell (subscription) in a test case)
- [x] syntax error exceptions