### PR TITLE
Fix issue with multiple input signals

### DIFF
--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -137,8 +137,8 @@
             (if (and (every? #{:<-} sugars) (every? vector? signals))
               (fn [sub-fn]
                 (fn input-fn
-                  ([_] (map sub-fn signals))
-                  ([_ _] (map sub-fn signals))))
+                  ([_] (mapv sub-fn signals))
+                  ([_ _] (mapv sub-fn signals))))
               (throw (Exception. (str "Expected pairs of `:<-` and vectors, got: " input-args))))))]
     {:signal-builder signal-builder
      :computation-fn computation-fn}))

--- a/test/hti/re_dash_test.cljd
+++ b/test/hti/re_dash_test.cljd
@@ -221,7 +221,7 @@
    :ab
    :<- [:a]
    :<- [:b]
-   :-> #(str %1 %2))
+   :-> (fn [[a b]] (str a b)))
 
   (is (= "ab" @(rd-testing/subscribe [:ab]))))
 

--- a/test/hti/re_dash_test.cljd
+++ b/test/hti/re_dash_test.cljd
@@ -208,6 +208,22 @@
                      (list :<- [::hoge] :<- [::fuga] :invalid> (fn [_ _]))))
           "Raises on unknown syntax sugar"))))
 
+(deftest subscribe-multiple-inputs
+  (rd/reg-sub
+   :a
+   (constantly "a"))
+
+  (rd/reg-sub
+   :b
+   (constantly "b"))
+
+  (rd/reg-sub
+   :ab
+   :<- [:a]
+   :<- [:b]
+   :-> #(str %1 %2))
+
+  (is (= "ab" @(rd-testing/subscribe [:ab]))))
 
 ;; Events
 


### PR DESCRIPTION
Fixes #19 

In `subscribe`, input signals are checked for vector? and map?. However in build-sub-map, in case of multiple input sugars, it uses `map`, resulting in a LazySeq which is neither a vector? nor a map?.

Trying to <! from (or deref) a LazySeq results in "No extension of protocol IDeref found for type LazySeq".

Using mapv in build-sub-map resolves the issue.

Added a test case for this scenario.