### PR TITLE
Better events queue implementation

### DIFF
--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -1,5 +1,6 @@
 (ns hti.re-dash
   (:require [cljd.flutter :as f]
+            [clojure.string :as string]
             ["dart:async" :as da]
             ["dart:collection" :as coll]))
 
@@ -335,6 +336,12 @@
   (when (.-isNotEmpty events-queue)
     (.removeFirst events-queue)))
 
+(defn- print-ex
+  "Prints an exception including stack trace to the console"
+  [e st]
+  (dart:core/print
+    (string/join "\r\n" [e st])))
+
 (defn- do-dispatch
   "Process this event, then the next in the queue, until the queue is empty."
   [event-vec]
@@ -346,11 +353,15 @@
   (reset! processing? true)
 
   (try
-    (let [event-id                                               (first event-vec)
-          {:keys [interceptors event-type] :as registered-event} (event-id @events)
-          all-interceptors                                       (concat [do-fx-interceptor
-                                    (prime-cofx-interceptor event-vec)]
-                                   interceptors)]
+    (let [event-id (first event-vec)
+
+          {:keys [interceptors event-type] :as registered-event}
+          (event-id @events)
+
+          all-interceptors
+          (concat [do-fx-interceptor
+                   (prime-cofx-interceptor event-vec)]
+                  interceptors)]
 
       (when-not registered-event
         (throw (Exception. (str "Event not found: " event-id))))
@@ -364,9 +375,11 @@
         (do-dispatch next-event-vec)
         (reset! processing? false)))
 
-    (catch dynamic e
-      (reset! processing? false)
-      (throw e))))
+    (catch dynamic e st
+           (print-ex e st)
+           (if-let [next-event-vec (dequeue)]
+             (do-dispatch next-event-vec)
+             (reset! processing? false)))))
 
 (defn- trigger
   "Trigger do-dispatch if no event is busy processing"

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -338,6 +338,13 @@
 (defn- do-dispatch
   "Process this event, then the next in the queue, until the queue is empty."
   [event-vec]
+
+  ;; Ensure we do not allow concurrent event execution.
+  ;; We open the gate again later after either
+  ;; - All events on the queue have been processed
+  ;; - Or an exception occurred
+  (reset! processing? true)
+
   (try
     (let [event-id                                               (first event-vec)
           {:keys [interceptors event-type] :as registered-event} (event-id @events)
@@ -365,11 +372,12 @@
   "Trigger do-dispatch if no event is busy processing"
   []
   (when (not @processing?)
-    (reset! processing? true)
     (-> (dequeue) do-dispatch)))
 
 (defn- enqueue
-  "Adds this event to the queue and trigger do-dispatch"
+  "Adds this event to the queue and trigger a do-dispatch.
+  Happens asynchronously so as to not hold up the event loop
+  and cause UI stutter"
   [event-vec]
   (.add ^coll/Queue events-queue event-vec)
   (trigger))

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -347,9 +347,8 @@
   [event-vec]
 
   ;; Ensure we do not allow concurrent event execution.
-  ;; We open the gate again later after either
-  ;; - All events on the queue have been processed
-  ;; - Or an exception occurred
+  ;; We open the gate again later after all events on the queue have been processed.
+  ;; In case of an exception, we'll log it to console and continue processing the remaining queue.
   (reset! processing? true)
 
   (try

--- a/src/hti/re_dash.cljd
+++ b/src/hti/re_dash.cljd
@@ -1,6 +1,7 @@
 (ns hti.re-dash
   (:require [cljd.flutter :as f]
-            ["dart:async" :as da]))
+            ["dart:async" :as da]
+            ["dart:collection" :as coll]))
 
 
 ;; Database
@@ -228,17 +229,17 @@
     (condp = effect-id
 
       :dispatch
-      (.add ^da/StreamController events-queue (:dispatch effects))
+      (enqueue (:dispatch effects))
 
       :dispatch-later
       (let [{:keys [ms dispatch]} (:dispatch-later effects)]
         (da/Future.delayed (Duration .milliseconds ms)
-                           #(.add ^da/StreamController events-queue dispatch)))
+                           #(enqueue dispatch)))
 
       :fx
       (doseq [[effect-id effect] (->> effects :fx (remove nil?))]
         (if (#{:dispatch :dispatch-later} effect-id)
-          (.add ^da/StreamController events-queue effect)
+          (enqueue effect)
           (execute! effect-id effect)))
 
       :deregister-event-handler
@@ -323,28 +324,55 @@
 
 ;; Events Queue
 
+(defonce ^:private ^coll/Queue events-queue
+  (coll/Queue))
+
+(defonce ^:private processing? (atom false))
+
+(defn- dequeue
+  "If the queue is not empty, take the first event off the queue"
+  []
+  (when (.-isNotEmpty events-queue)
+    (.removeFirst events-queue)))
+
 (defn- do-dispatch
+  "Process this event, then the next in the queue, until the queue is empty."
   [event-vec]
-  (let [event-id (first event-vec)
-        {:keys [interceptors event-type] :as registered-event} (event-id @events)
-        all-interceptors (concat [do-fx-interceptor
-                                  (prime-cofx-interceptor event-vec)]
-                                 interceptors)]
+  (try
+    (let [event-id                                               (first event-vec)
+          {:keys [interceptors event-type] :as registered-event} (event-id @events)
+          all-interceptors                                       (concat [do-fx-interceptor
+                                    (prime-cofx-interceptor event-vec)]
+                                   interceptors)]
 
-    (when-not registered-event
-      (throw (Exception. (str "Event not found: " event-id))))
+      (when-not registered-event
+        (throw (Exception. (str "Event not found: " event-id))))
 
-    (->> (await (interceptors-sweep-before event-type event-vec all-interceptors))
-         (interceptors-sweep-after all-interceptors))))
+      (->> (interceptors-sweep-before event-type event-vec all-interceptors)
+           await
+           (interceptors-sweep-after all-interceptors)
+           await)
 
-(defonce ^:private events-queue
-  (let [controller (da/StreamController)]
+      (if-let [next-event-vec (dequeue)]
+        (do-dispatch next-event-vec)
+        (reset! processing? false)))
 
-    (.listen (.-stream controller)
-             (fn [event-vec]
-               (await (do-dispatch event-vec))))
+    (catch dynamic e
+      (reset! processing? false)
+      (throw e))))
 
-    controller))
+(defn- trigger
+  "Trigger do-dispatch if no event is busy processing"
+  []
+  (when (not @processing?)
+    (reset! processing? true)
+    (-> (dequeue) do-dispatch)))
+
+(defn- enqueue
+  "Adds this event to the queue and trigger do-dispatch"
+  [event-vec]
+  (.add ^coll/Queue events-queue event-vec)
+  (trigger))
 
 
 ;; Events
@@ -490,7 +518,7 @@
       (dispatch [:order \"pizza\" {:supreme 2 :meatlovers 1 :veg 1}])
   "
   [event-vec]
-  (.add ^da/StreamController events-queue event-vec))
+  (enqueue event-vec))
 
 (defn register-defaults!
   "Optional default registrations for convenience"

--- a/test/hti/re_dash_test.cljd
+++ b/test/hti/re_dash_test.cljd
@@ -344,6 +344,12 @@
       (fn [cofx _]
         (assoc cofx :add-val 5)))
 
+    (rd/reg-cofx
+    :add-val-future
+    (fn [cofx _]
+      (assoc cofx :add-val (await (Future.delayed (Duration .milliseconds 1)
+                                                  (constantly 5))))))
+
     (rd/reg-event-fx
       :count
       [(rd/inject-cofx :add-val)]                  ;; <== The test
@@ -353,7 +359,7 @@
 
     (rd/reg-event-fx
       :count-another
-      [(rd/inject-cofx :add-val)]                  ;; <== The test
+      [(rd/inject-cofx :add-val-future)]           ;; <== The test
       (fn [{:keys [db add-val]} _]
         (let [current-count (+ (:current-count db 0) add-val)]
           {:db (assoc db :current-count current-count)})))
@@ -370,4 +376,37 @@
 
       (da/Future.delayed (Duration .milliseconds 1000)
                          #(is (= 10
+                                 @(rd-testing/subscribe [:get-count])))))))
+
+(deftest dispatch-multiple-events-in-queue-one-exception
+
+  (testing "Ordered event queue execution including coeffects. See Github issue: 21"
+
+    (rd/reg-event-fx
+      :count
+      (fn [{:keys [db]} _]
+        (let [current-count (inc (:current-count db 0))]
+          {:db (assoc db :current-count current-count)})))
+
+    (rd/reg-event-fx
+      :exception
+      (fn [_ _]
+        (throw (Exception. "This exception is part of a test case, and can be safely ignored."))))
+
+    (rd/reg-event-fx
+      :do-counts
+      (fn [_ _]
+        {:fx [[:dispatch [:count]]
+              [:dispatch [:count]]
+              [:dispatch [:count]]
+              [:dispatch [:exception]]
+              [:dispatch [:count]]
+              [:dispatch [:count]]]}))
+
+    (rd/dispatch [:do-counts])
+
+    (testing "End result in app-db should be 5"
+
+      (da/Future.delayed (Duration .milliseconds 1000)
+                         #(is (= 5
                                  @(rd-testing/subscribe [:get-count])))))))

--- a/test/hti/re_dash_test.cljd
+++ b/test/hti/re_dash_test.cljd
@@ -1,5 +1,6 @@
 (ns hti.re-dash-test
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require ["dart:async" :as da]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [cljd.flutter :as f]
             [hti.re-dash :as rd]
             [hti.re-dash-testing :as rd-testing]))
@@ -333,3 +334,40 @@
 
     (is (= {:count 5}
            @(rd-testing/subscribe [:get-count-path])))))
+
+(deftest dispatch-multiple-events-incl-cofx-check-state
+
+  (testing "Ordered event queue execution including coeffects. See Github issue: 21"
+
+    (rd/reg-cofx
+      :add-val
+      (fn [cofx _]
+        (assoc cofx :add-val 5)))
+
+    (rd/reg-event-fx
+      :count
+      [(rd/inject-cofx :add-val)]                  ;; <== The test
+      (fn [{:keys [db add-val]} _]
+        (let [current-count (+ (:current-count db 0) add-val)]
+          {:db (assoc db :current-count current-count)})))
+
+    (rd/reg-event-fx
+      :count-another
+      [(rd/inject-cofx :add-val)]                  ;; <== The test
+      (fn [{:keys [db add-val]} _]
+        (let [current-count (+ (:current-count db 0) add-val)]
+          {:db (assoc db :current-count current-count)})))
+
+    (rd/reg-event-fx
+      :do-counts
+      (fn [_ _]
+        {:fx [[:dispatch [:count]]
+              [:dispatch [:count-another]]]}))
+
+    (rd/dispatch [:do-counts])
+
+    (testing "End result in app-db should be 10 (both Coeffects adding 5)"
+
+      (da/Future.delayed (Duration .milliseconds 1000)
+                         #(is (= 10
+                                 @(rd-testing/subscribe [:get-count])))))))


### PR DESCRIPTION
Fixes #21 

An [issue was raised](https://clojurians.slack.com/archives/C03A6GE8D32/p1699842398688649) w.r.t. the app-db not reflecting the correct end result when multiple events dispatched from an `:fx` effect were used in conjunction with re-dash coeffects injected into event handlers.

After investigation, and with the help of @valerauko minimal reproduction, I was able to determine the cause was related to (un)ordered event execution. 

### StreamController

The initial attempt to guarantee ordered event execution was implemented using [StreamController](https://api.flutter.dev/flutter/dart-async/StreamController-class.html) - The history of how this came to be can be found in the [slack thread](https://clojurians.slack.com/archives/C03A6GE8D32/p1689846419902579)

For the most part this worked well, however when used in conjuction with re-dash coeffects, this caused the event execution order to fluctuate (dart's async / await fun)

### Queue

This PR addresses the issue with a better events queue implementation using [Queue](https://api.flutter.dev/flutter/dart-collection/Queue-class.html) in combination with a `processing?` gatekeeper (with the help of an `atom`).

Events are now properly ordered regardless whether they're dispatched directly, or within the `:fx` effect, and coeffects (Future or otherwise) does not interfere with this.

### Testing

- All [samples](https://github.com/htihospitality/re-dash/tree/main/samples) work as expected
- All existing [tests](https://github.com/htihospitality/re-dash/blob/main/test/hti/re_dash_test.cljd) pass
- New [test](https://github.com/htihospitality/re-dash/blob/better-events-queue/test/hti/re_dash_test.cljd#L338) added to simulate  the issue #21 raised (fails on main, passes on this branch)
- The [repro code](https://github.com/valerauko/re-dash-repro) for issue #21 works as expected.





