### PR TITLE
clear-flow effect fixes

### DIFF
--- a/src/hti/re_dash/flows.cljd
+++ b/src/hti/re_dash/flows.cljd
@@ -218,18 +218,18 @@
   [flow-id]
   (swap! flows
          (fn [{:keys [definitions sorted-ids] :as flows}]
-           (let [flow (get-flow flow-id definitions)]
-
-             (-> (update flows :definitions dissoc flow-id)
-                 (assoc :sorted-ids
-                        (remove #(#{flow-id} %)
-                                sorted-ids)))
+           (let [flow (flow-id definitions)]
 
              (swap! app-db/app-db
                     #(exec-flow-action {:action      ::cleanup
                                         :flow        flow
                                         :new-db      %
-                                        :definitions definitions}))))))
+                                        :definitions definitions}))
+
+             (-> (update flows :definitions dissoc flow-id)
+                 (assoc :sorted-ids
+                        (remove #(#{flow-id} %)
+                                sorted-ids)))))))
 
 (defn- path
   [query-vec]


### PR DESCRIPTION
Fixed `:clear-flow` effect to 

- not throw an exception when flow cannot be found
- not wipe all flows, only the one specified