### PR TITLE
Fixed Cell memory leak in signaled subscriptions

### DIFF
--- a/src/hti/re_dash/alpha.cljd
+++ b/src/hti/re_dash/alpha.cljd
@@ -2,6 +2,7 @@
   (:require ["dart:async" :as da]
             ["dart:collection" :as coll]
             [cljd.flutter :as f]
+            [cljd.core :as c]
             [clojure.string :as string]
             [clojure.data :as data]
             [hti.re-dash.debugging :as debugging]
@@ -14,7 +15,7 @@
 
 (defonce ^:private subscriptions (atom {}))
 
-(defn- map->signals
+(defn- map->resolved-signals
   [signals]
   (->> (map (fn [[k v]]
               {k (f/<! v)})
@@ -33,6 +34,21 @@
   "Checks if the supplied query-vec is a Flow"
   [query-vec]
   (= :flow (first query-vec)))
+
+(defonce ^:private signal-cache (atom {}))
+
+(defn- ->signals
+  "Resolve subscription signals using the signal-builder.
+
+  Signals are cached so their Cell instances gets re-used
+  during the lifetime of the subscription.
+  "
+  [signal-builder [subscription-id query :as query-vec]]
+  (or (get-in @signal-cache [subscription-id query])
+      (let [signals' ((signal-builder subscribe) query-vec)]
+        (when-not (dart/is? signals' c/Atom)
+          (swap! signal-cache #(assoc-in % [subscription-id query] signals')))
+        signals')))
 
 (defn subscribe
   "Subscribe to derived state, internally using ClojureDart Cells (see the [Cheatsheet](https://github.com/Tensegritics/ClojureDart/blob/main/doc/ClojureDart%20Cheatsheet.pdf))
@@ -76,10 +92,10 @@
       (if-let [{:keys [signal-builder computation-fn]}
                (get @subscriptions subscription-id)]
         (f/$ (computation-fn
-               (let [signals ((signal-builder subscribe) query-vec)]
+               (let [signals (->signals signal-builder query-vec)]
                  (cond
                    (vector? signals) (map #(f/<! %) signals)
-                   (map? signals)    (map->signals signals)
+                   (map? signals)    (map->resolved-signals signals)
                    :else             (f/<! signals)))
                query-vec))
         (throw (Exception. (str "Subscription not found: " subscription-id)))))))

--- a/src/hti/re_dash/core.cljd
+++ b/src/hti/re_dash/core.cljd
@@ -2,6 +2,7 @@
   (:require ["dart:async" :as da]
             ["dart:collection" :as coll]
             [cljd.flutter :as f]
+            [cljd.core :as c]
             [clojure.string :as string]
             [clojure.data :as data]
             [hti.re-dash.debugging :as debugging]
@@ -13,7 +14,7 @@
 
 (defonce ^:private subscriptions (atom {}))
 
-(defn- map->signals
+(defn- map->resolved-signals
   [signals]
   (->> (map (fn [[k v]]
               {k (f/<! v)})
@@ -27,6 +28,22 @@
               {k @v})
             signals)
        (into {})))
+
+
+(defonce ^:private signal-cache (atom {}))
+
+(defn- ->signals
+  "Resolve subscription signals using the signal-builder.
+
+  Signals are cached so their Cell instances gets re-used
+  during the lifetime of the subscription.
+  "
+  [signal-builder [subscription-id query :as query-vec]]
+  (or (get-in @signal-cache [subscription-id query])
+      (let [signals' ((signal-builder subscribe) query-vec)]
+        (when-not (dart/is? signals' c/Atom)
+          (swap! signal-cache #(assoc-in % [subscription-id query] signals')))
+        signals')))
 
 (defn subscribe
   "Subscribe to derived state, internally using ClojureDart Cells (see the [Cheatsheet](https://github.com/Tensegritics/ClojureDart/blob/main/doc/ClojureDart%20Cheatsheet.pdf))
@@ -66,17 +83,17 @@
     (if-let [{:keys [signal-builder computation-fn]}
              (get @subscriptions subscription-id)]
       (f/$
-       (try
-         (computation-fn
-          (let [signals ((signal-builder subscribe) query-vec)]
-            (cond
-              (vector? signals) (map #(f/<! %) signals)
-              (map? signals)    (map->signals signals)
-              :else             (f/<! signals)))
-          query-vec)
-         (catch dynamic ex st
-           (println (str "Error while calculating subscription " subscription-id
-                         " - " ex "\n" st)))))
+        (try
+          (computation-fn
+            (let [signals (->signals signal-builder query-vec)]
+              (cond
+                (vector? signals) (map #(f/<! %) signals)
+                (map? signals)    (map->resolved-signals signals)
+                :else             (f/<! signals)))
+            query-vec)
+          (catch dynamic ex st
+                 (println (str "Error while calculating subscription " subscription-id
+                               " - " ex "\n" st)))))
       (throw (Exception. (str "Subscription not found: " subscription-id))))))
 
 (defn derefable-subscribe


### PR DESCRIPTION
When using input signals with subscriptions ([layer 3 - materialized views](https://day8.github.io/re-frame/subscriptions/#the-four-layers)) I've noticed gradually degraded responsiveness in a UI that subscribed to many of these form of subscriptions.

Upon investigation, and with the help of the Flutter Dev Tools, I've identified an issue that seemed to point to a memory leak of `Cell` instances:

![devtools](https://github.com/htihospitality/re-dash/assets/5214136/e0eb0e17-c6a8-479c-ae69-6458fc72b1fa)

And indeed after some debugging, I've confirmed that when re-dash subscriptions were used as input signals, they created new `Cell` instances each time the signal gets resolved to a new value, and the _old_ `Cell` was not garbage collected (probably because it remained referenced by its original dependencies)

This is corrected in this PR by introducing a signal cache (a registry if you will, like we use for normal subscriptions registered with `reg-sub`, but only for subscription signals) 

This is managed internally by re-dash (as with all other regsitries) no changes required to existing code.

Result is much better UI responsivenes that does not degrade over time, and Flutter Dev Tools agree:

![image](https://github.com/htihospitality/re-dash/assets/5214136/b296728b-6505-4496-b66d-2126470534f2)
 
