### PR TITLE
Swapped flow execution order to consider custom interceptor changes

### DIFF
--- a/src/hti/re_dash/alpha.cljd
+++ b/src/hti/re_dash/alpha.cljd
@@ -466,9 +466,9 @@
           all-interceptors
           (concat [do-fx-interceptor
                    (prime-cofx-interceptor event-vec)]
+                  [flows/flow-interceptor]
                   @global-interceptors
-                  interceptors
-                  [flows/flow-interceptor])]
+                  interceptors)]
 
       (when-not registered-event
         (throw (Exception. (str "Event not found: " event-id))))

--- a/src/hti/re_dash/flows.cljd
+++ b/src/hti/re_dash/flows.cljd
@@ -121,6 +121,7 @@
 (def flow-interceptor
   (interceptors/->interceptor
     :re-dash/flow
+    nil
     (fn [{{db :db} :effects
           :as      context}]
       (let [old-db                           @app-db/app-db
@@ -139,8 +140,7 @@
                                     exec-flow-action)
                                 new-db)))
                           (or db old-db)
-                          sorted-ids))))
-    nil))
+                          sorted-ids))))))
 
 
 (defn sort-flow-ids


### PR DESCRIPTION
This PR fixes an issue where changes made to the db via custom interceptors' `after` phase were not available during flow execution.